### PR TITLE
Remove dependency on `fs` package

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   "dependencies": {
     "async": "^0.9.0",
     "cheerio": "^0.18.0",
-    "fs": "0.0.2",
     "mongodb": "^1.4.30",
     "nodemw": "^0.4.1",
     "string": "^3.0.0"


### PR DESCRIPTION
Hello!

You might not be aware of this, but the `fs` module that you `require()` here is actually [a core Node.js module](http://nodejs.org/api/fs.html). This means that it comes with every installation of Node.js.

In your `package.json`, you have [this `fs` module](https://www.npmjs.com/package/fs) as a dependency. Yet, technically you are never using this module. Due to how `require()` is implemented, core modules take precedence over `npm` packages. As such, when you do:

``` js
var fs = require('fs');
```

You are getting the core `fs` module I mentioned earlier, not the `fs` module from `npm` that you seem to have a dependency on. Furthermore, this `fs` module on `npm` is literally nothing more than a `console.log`:

``` sh
$ npm install fs
$ cat node_modules/fs/index.js
console.log("I'm `fs` modules");
```

So, this patch removes the dependency on this useless module.

Thanks for your time :)